### PR TITLE
Fix: Revert merchant fee calculation changes

### DIFF
--- a/config/fee_schedules.json
+++ b/config/fee_schedules.json
@@ -1,16 +1,32 @@
-// Rollback: Revert merchant fee calculation changes
-// Emergency rollback of fee calculation changes that caused incorrect merchant payouts. Reverting to previous stable version while investigating root cause.
+// Fix: Revert merchant fee calculation changes
+// **EMERGENCY ROLLBACK** - Incident #INC-2024-1156
 
-// PR ID: 2
+**Issue**: Merchant fee calculation v2.1 deployed at 14:32 UTC causing incorrect fee calculations:
+- 847 merchants overpaid by average $23.45 (total $19,526 impact)
+- 1,203 merchants underpaid by average $8.67 (total $10,430 impact)
+- Affects all transactions processed between 14:32-15:45 UTC
+
+**Immediate Actions**:
+- Reverting to fee_calculator.py v2.0.3 (last known good version)
+- Pausing all fee processing until rollback complete
+- Finance team calculating merchant reimbursements
+
+**Next Steps**:
+- Post-incident review scheduled for tomorrow 10am
+- Fee calculation v2.1 pulled from production deployment pipeline
+- Additional integration tests required before next fee calculation changes
+
+
+// PR ID: 1
 // Author: diana-architect
-// Generated: 2025-08-06T22:18:39.294067
+// Generated: 2025-08-07T10:36:53.987298
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define VERSION "1.0.0"
-#define PR_ID 2
+#define PR_ID 1
 
 typedef struct {
     int id;
@@ -24,7 +40,7 @@ int process_data(ProcessedItem* items, int count) {
     }
     
     for (int i = 0; i < count; i++) {
-        // Apply changes for Rollback: Revert merchant fee calculation changes
+        // Apply changes for Fix: Revert merchant fee calculation changes
         snprintf(items[i].status, sizeof(items[i].status), "processed_pr_%d", PR_ID);
     }
     
@@ -32,6 +48,6 @@ int process_data(ProcessedItem* items, int count) {
 }
 
 int main() {
-    printf("Running code for PR #%d: %s\n", PR_ID, "Rollback: Revert merchant fee calculation changes");
+    printf("Running code for PR #%d: %s\n", PR_ID, "Fix: Revert merchant fee calculation changes");
     return 0;
 }

--- a/src/fee_calculator.py
+++ b/src/fee_calculator.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python3
 """
-Rollback: Revert merchant fee calculation changes
+Fix: Revert merchant fee calculation changes
 
-This module implements changes related to: Emergency rollback of fee calculation changes that caused incorrect merchant payouts. Reverting to previous stable version while investigating root cause.
+This module implements changes related to: **EMERGENCY ROLLBACK** - Incident #INC-2024-1156
+
+**Issue**: Merchant fee calculation v2.1 deployed at 14:32 UTC causing incorrect fee calculations:
+- 847 merchants overpaid by average $23.45 (total $19,526 impact)
+- 1,203 merchants underpaid by average $8.67 (total $10,430 impact)
+- Affects all transactions processed between 14:32-15:45 UTC
+
+**Immediate Actions**:
+- Reverting to fee_calculator.py v2.0.3 (last known good version)
+- Pausing all fee processing until rollback complete
+- Finance team calculating merchant reimbursements
+
+**Next Steps**:
+- Post-incident review scheduled for tomorrow 10am
+- Fee calculation v2.1 pulled from production deployment pipeline
+- Additional integration tests required before next fee calculation changes
+
 """
 
 import os
@@ -12,8 +28,8 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
-class Rollback:RevertmerchantfeecalculationchangesHandler:
-    """Handler for rollback: revert merchant fee calculation changes"""
+class Fix:RevertmerchantfeecalculationchangesHandler:
+    """Handler for fix: revert merchant fee calculation changes"""
     
     def __init__(self):
         self.initialized_at = datetime.now()
@@ -22,7 +38,7 @@ class Rollback:RevertmerchantfeecalculationchangesHandler:
     def process(self, data):
         """Process the data according to new requirements"""
         try:
-            # Implementation for Rollback: Revert merchant fee calculation changes
+            # Implementation for Fix: Revert merchant fee calculation changes
             result = self._apply_changes(data)
             logger.info(f"Successfully processed data: {len(data) if data else 0} items")
             return result
@@ -32,7 +48,23 @@ class Rollback:RevertmerchantfeecalculationchangesHandler:
     
     def _apply_changes(self, data):
         """Apply the specific changes for this PR"""
-        # Changes related to: Emergency rollback of fee calculation changes that caused incorrect merchant payouts. Reverting to previous stable version while investigating root cause.
+        # Changes related to: **EMERGENCY ROLLBACK** - Incident #INC-2024-1156
+
+**Issue**: Merchant fee calculation v2.1 deployed at 14:32 UTC causing incorrect fee calculations:
+- 847 merchants overpaid by average $23.45 (total $19,526 impact)
+- 1,203 merchants underpaid by average $8.67 (total $10,430 impact)
+- Affects all transactions processed between 14:32-15:45 UTC
+
+**Immediate Actions**:
+- Reverting to fee_calculator.py v2.0.3 (last known good version)
+- Pausing all fee processing until rollback complete
+- Finance team calculating merchant reimbursements
+
+**Next Steps**:
+- Post-incident review scheduled for tomorrow 10am
+- Fee calculation v2.1 pulled from production deployment pipeline
+- Additional integration tests required before next fee calculation changes
+
         if not data:
             return []
         
@@ -42,7 +74,7 @@ class Rollback:RevertmerchantfeecalculationchangesHandler:
             enhanced_item = {
                 **item,
                 'processed_at': datetime.now().isoformat(),
-                'pr_id': 2,
+                'pr_id': 1,
                 'version': '1.0.0'
             }
             processed.append(enhanced_item)
@@ -51,7 +83,7 @@ class Rollback:RevertmerchantfeecalculationchangesHandler:
 
 def main():
     """Main function for testing"""
-    handler = Rollback:RevertmerchantfeecalculationchangesHandler()
+    handler = Fix:RevertmerchantfeecalculationchangesHandler()
     test_data = [{"id": 1, "name": "test"}, {"id": 2, "name": "demo"}]
     result = handler.process(test_data)
     print(f"Processed {len(result)} items")


### PR DESCRIPTION
**EMERGENCY ROLLBACK** - Incident #INC-2024-1156

**Issue**: Merchant fee calculation v2.1 deployed at 14:32 UTC causing incorrect fee calculations:
- 847 merchants overpaid by average $23.45 (total $19,526 impact)
- 1,203 merchants underpaid by average $8.67 (total $10,430 impact)
- Affects all transactions processed between 14:32-15:45 UTC

**Immediate Actions**:
- Reverting to fee_calculator.py v2.0.3 (last known good version)
- Pausing all fee processing until rollback complete
- Finance team calculating merchant reimbursements

**Next Steps**:
- Post-incident review scheduled for tomorrow 10am
- Fee calculation v2.1 pulled from production deployment pipeline
- Additional integration tests required before next fee calculation changes
